### PR TITLE
Solucion de errores menores.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+#Firebase
+.firebaserc
+firebase.json
+.firebase

--- a/src/app/mis-componentes/habilidades/skill-item/skill-item.component.html
+++ b/src/app/mis-componentes/habilidades/skill-item/skill-item.component.html
@@ -37,7 +37,7 @@
                 <option value="Soft">Soft</option></select>
             </div>
         <div *ngIf="editando">
-            <button class="btn btn-success m-1 mt-0 " [disabled]="!HayCambios()" (click)="guardarCambios()">Guardar Cambios</button>
+            <button class="btn btn-success m-1 mt-0 " [disabled]="!(HayCambios()||tipoProvicional!=item.tipo)" (click)="guardarCambios()">Guardar Cambios</button>
             <button class="btn btn-secondary m-1 mt-0" (click)="cancel()">Cancelar</button>
         </div>        
     </div>


### PR DESCRIPTION
Ahora un item de habilidad puede guardar sus cambios con solo cambiar de tipo.
Actualizado '.gitignore' para que no suba los archivos de firebase.